### PR TITLE
Fix dev check

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -3,7 +3,7 @@ import { parseRequest } from './_lib/parser';
 import { getScreenshot } from './_lib/chromium';
 import { getHtml } from './_lib/template';
 
-const isDev = process.env.VERCEL_REGION === 'dev1';
+const isDev = !process.env.AWS_REGION;
 const isHtmlDebug = process.env.OG_HTML_DEBUG === '1';
 
 export default async function handler(req: IncomingMessage, res: ServerResponse) {


### PR DESCRIPTION
Fixes #123 

This is not the ideal solution but the design for `VERCEL_REGION` env var is still in progress--its not clear if it should always be assigned or only when the user opt's in.

So this PR implements a workaround for detecting dev since `AWS_REGION` is a Reserved Environment Variable that is always assigned in production.

- Vercel Docs: https://vercel.com/docs/v2/platform/limits#reserved-variables
- AWS Docs: https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
- Upstream Fix TBD: https://github.com/vercel/vercel/pull/4855