### PR TITLE
Update broken readme tweet banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # [Open Graph Image as a Service](https://og-image.vercel.app)
 
-<a href="https://twitter.com/vercel/status/1092587111985881088">
-    <img align="right" src="https://raw.githubusercontent.com/vercel/og-image/master/public/tweet.png" height="300" />
+<a href="https://twitter.com/vercel">
+    <img align="right" src="./public/tweet.png" height="300" />
 </a>
 
 Serverless service that generates dynamic Open Graph images that you can embed in your `<meta>` tags.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # [Open Graph Image as a Service](https://og-image.vercel.app)
 
 <a href="https://twitter.com/vercel">
-    <img align="right" src="./public/tweet.png" height="300" />
+    <img align="right" src="https://og-image.vercel.app/tweet.png" height="300" />
 </a>
 
 Serverless service that generates dynamic Open Graph images that you can embed in your `<meta>` tags.


### PR DESCRIPTION
Hey, thanks for this amazing project! 💯 

# Issues

I just saw the currently embedded tweet image in the readme is broken, on all browsers and it seems to look terrible on some, as shown below.

**Mozilla Firefox**
![https://i.imgur.com/aayaJEv.png](https://i.imgur.com/aayaJEv.png)

**Microsoft Edge**
![https://i.imgur.com/EFaUZAH.png](https://i.imgur.com/EFaUZAH.png)

# Fixes

**So, I updated the src link of the image to the correct path.**

And also I searched for the actual tweet on Twitter as the current href link of the `a` tag also seems to be broken as no tweet is available with that id.

![https://i.imgur.com/v6dz5JM.png](https://i.imgur.com/v6dz5JM.png)

**So, I linked the href to the official [vercel](https://twitter.com/vercel) account on twitter**

Hope, this looks good to the community. 😄 
