### PR TITLE
Fix select component styles

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -186,7 +186,7 @@ select {
     font-size: 14px;
     margin-right: -20px;
     width: calc(100% + 20px);
-    padding: 0 76px 0 16px;
+    padding: 0 0 0 16px;
     text-transform: none;
 }
 


### PR DESCRIPTION
Hi I don't think it is necessary to set the `padding-right` of Select component to 76px. It causes a problem:

![pic](https://user-images.githubusercontent.com/16490377/91298038-e090f980-e7d1-11ea-9180-44aa8b2f0754.png)
