### PR TITLE
Fix puppeteer import

### DIFF
--- a/api/_lib/chromium.ts
+++ b/api/_lib/chromium.ts
@@ -1,14 +1,14 @@
-import { launch, Page } from 'puppeteer-core';
+import core from 'puppeteer-core';
 import { getOptions } from './options';
 import { FileType } from './types';
-let _page: Page | null;
+let _page: core.Page | null;
 
 async function getPage(isDev: boolean) {
     if (_page) {
         return _page;
     }
     const options = await getOptions(isDev);
-    const browser = await launch(options);
+    const browser = await core.launch(options);
     _page = await browser.newPage();
     return _page;
 }


### PR DESCRIPTION
When users clone this repo and changed TS to JS source files, they would see the following error:

```
TypeError: Cannot read property '_launcher' of undefined
```

This is because TS imports the entire module, not just the single function, so it didn't suffer from the unbounded `this`.

This PR changes the import so it will work with either JS or TS.


### Related
- https://twitter.com/daheqcom/status/1347982852454019072
- https://stackoverflow.com/q/57705213/266535
- https://github.com/felixheck/minimal-thingy/pull/1