### PR TITLE
Simplify build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "14.x"
   },
   "scripts": {
-    "build": "tsc -p api/tsconfig.json && tsc -p web/tsconfig.json"
+    "build": "tsc -p web/tsconfig.json"
   },
   "dependencies": {
     "chrome-aws-lambda": "7.0.0",

--- a/web/index.ts
+++ b/web/index.ts
@@ -1,4 +1,4 @@
-import { ParsedRequest, Theme, FileType } from '../api/_lib/types';
+import type { ParsedRequest, Theme, FileType } from '../api/_lib/types';
 const { H, R, copee } = (window as any);
 let timeout = -1;
 


### PR DESCRIPTION
The `api` directory is built automatically so the build script only needs to build the frontend