### PR TITLE
fix: If a period is included, subsequent characters are not interpreted.

### DIFF
--- a/api/_lib/parser.ts
+++ b/api/_lib/parser.ts
@@ -22,7 +22,7 @@ export function parseRequest(req: IncomingMessage) {
     } else if (arr.length === 1) {
         text = arr[0];
     } else {
-        extension = arr.pop() as string;
+        extension = [...arr].pop() as string;
         text = arr.join('.');
     }
 


### PR DESCRIPTION
Hi! 
Thank you very much for providing us with a great library.

Fixed a problem in which if a parsed string contained a period, the characters after the period were omitted.

Before
`Next.js → Next`

After
`Next.js → Next.js`