### PR TITLE
[twemoji] Migrate from MaxCDN to jsDelivr

### DIFF
--- a/api/_lib/template.ts
+++ b/api/_lib/template.ts
@@ -4,7 +4,11 @@ import { marked } from 'marked';
 import { sanitizeHtml } from './sanitizer';
 import { ParsedRequest } from './types';
 const twemoji = require('twemoji');
-const twOptions = { folder: 'svg', ext: '.svg' };
+const twOptions = {
+    base: 'https://cdn.jsdelivr.net/gh/twitter/twemoji@13.0.1/assets/',
+    folder: 'svg',
+    ext: '.svg',
+};
 const emojify = (text: string) => twemoji.parse(text, twOptions);
 
 const rglr = readFileSync(`${__dirname}/../_fonts/Inter-Regular.woff2`).toString('base64');


### PR DESCRIPTION
ref. https://github.com/twitter/twemoji/issues/580#issuecomment-1376299586

pointing to `13.0.1` as per:
https://github.com/vercel/og-image/blob/main/package.json#L13